### PR TITLE
common: clean warning

### DIFF
--- a/common/mediaserver.te
+++ b/common/mediaserver.te
@@ -16,6 +16,7 @@ allow mediaserver camera_data_file:sock_file write;
 userdebug_or_eng(`
   allow mediaserver camera_data_file:dir rw_dir_perms;
   allow mediaserver camera_data_file:file create_file_perms;
+  allow mediaserver debugfs:file rw_file_perms;
 ')
 
 allow mediaserver sysfs_esoc:dir r_dir_perms;
@@ -45,8 +46,3 @@ allow mediaserver time_daemon:unix_stream_socket connectto;
 # Allow mediaserver to create socket files for audio arbitration
 allow mediaserver audio_data_file:sock_file { create setattr unlink };
 allow mediaserver audio_data_file:dir remove_name;
-
-#access to audio
-userdebug_or_eng('
-allow mediaserver debugfs:file rw_file_perms;
-')


### PR DESCRIPTION
device/qcom/sepolicy/common/mediaserver.te:50:WARNING 'unrecognized character' at token ''' on line 16816:
'
device/qcom/sepolicy/common/mediaserver.te:50:WARNING 'unrecognized character' at token ''' on line 16820:
'

related to commit: 79af968d43c8a031f8c8142356839461012e84d9

Signed-off-by: David Viteri davidteri91@gmail.com
