### PR TITLE
common: remove duplicate

### DIFF
--- a/common/device.te
+++ b/common/device.te
@@ -29,9 +29,6 @@ type hvdcp_device, dev_type;
 #Define mpdecision device
 type device_latency, dev_type;
 
-#Define rct device type for time daemon
-type rtc_device, dev_type;
-
 #Added for fm_radio device
 type  fm_radio_device, dev_type;
 

--- a/common/file_contexts
+++ b/common/file_contexts
@@ -15,7 +15,6 @@
 /dev/qseecom                                    u:object_r:tee_device:s0
 /dev/seemplog                                   u:object_r:seemplog_device:s0
 /dev/radio0                                     u:object_r:fm_radio_device:s0
-/dev/rtc0                                       u:object_r:rtc_device:s0
 /dev/sensors                                    u:object_r:sensors_device:s0
 /dev/smd.*                                      u:object_r:smd_device:s0
 /dev/smem_log                                   u:object_r:smem_log_device:s0


### PR DESCRIPTION
device/qcom/sepolicy/common/device.te:34:ERROR 'duplicate declaration of type/attribute' at token ';' on line 14226:
type rtc_device, dev_type;
checkpolicy:  error(s) encountered while parsing configuration

see string 15: https://android.googlesource.com/platform/external/sepolicy/+/android-m-preview/device.te
see string 80: https://android.googlesource.com/platform/external/sepolicy/+/android-m-preview/file_contexts

Signed-off-by: David Viteri davidteri91@gmail.com
