### PR TITLE
sepolicy: update selinux paths

### DIFF
--- a/common/file_contexts
+++ b/common/file_contexts
@@ -115,7 +115,7 @@
 /system/bin/diag_socket_log                     u:object_r:diag_exec:s0
 /system/bin/diag_uart_log                       u:object_r:diag_exec:s0
 /system/bin/drmdiagapp                          u:object_r:diag_exec:s0
-/system/bin/irsc_util                           u:object_r:irsc_util_exec:s0
+/system/vendor/bin/irsc_util                    u:object_r:irsc_util_exec:s0
 /system/bin/mm-pp-daemon                        u:object_r:mm-pp-daemon_exec:s0
 /system/bin/mmi                                 u:object_r:mmi_exec:s0
 /system/bin/mpdecision                          u:object_r:mpdecision_exec:s0
@@ -125,10 +125,10 @@
 /system/bin/imsqmidaemon                        u:object_r:ims_exec:s0
 /system/bin/ims_rtp_daemon                      u:object_r:ims_exec:s0
 /system/bin/imscmservice                        u:object_r:imscm_exec:s0
-/system/bin/netmgrd                             u:object_r:netmgrd_exec:s0
-/system/bin/qmuxd                               u:object_r:qmuxd_exec:s0
+/system/vendor/bin/netmgrd                      u:object_r:netmgrd_exec:s0
+/system/vendor/bin/qmuxd                        u:object_r:qmuxd_exec:s0
 /system/bin/port-bridge                         u:object_r:port-bridge_exec:s0
-/system/bin/sensors.qcom                        u:object_r:sensors_exec:s0
+/system/vendor/bin/sensors.qcom                 u:object_r:sensors_exec:s0
 /system/bin/sns.*                               u:object_r:sensors_test_exec:s0
 /system/bin/test_diag                           u:object_r:diag_exec:s0
 /system/bin/thermal-engine                      u:object_r:thermal-engine_exec:s0
@@ -136,7 +136,7 @@
 /system/bin/mm-qcamera-daemon                   u:object_r:mm-qcamerad_exec:s0
 /system/rfs.*                                   u:object_r:rfs_system_file:s0
 /system/bin/time_daemon                         u:object_r:time_daemon_exec:s0
-/system/bin/rmt_storage                         u:object_r:rmt_storage_exec:s0
+/system/vendor/bin/rmt_storage                  u:object_r:rmt_storage_exec:s0
 /system/bin/rfs_access                          u:object_r:rfs_access_exec:s0
 /system/bin/tftp_server                         u:object_r:rfs_access_exec:s0
 /system/bin/hvdcp                               u:object_r:hvdcp_exec:s0


### PR DESCRIPTION
follow general trend and move vendor blobs to /system/vendor/bin
for easy tracking

Signed-off-by: David Viteri davidteri91@gmail.com
