### PR TITLE
sepolicy: update mm-qcamera-daemon path

### DIFF
--- a/common/file_contexts
+++ b/common/file_contexts
@@ -148,7 +148,7 @@
 /system/bin/test_diag                           u:object_r:diag_exec:s0
 /system/vendor/bin/thermal-engine               u:object_r:thermal-engine_exec:s0
 /system/bin/vm_bms                              u:object_r:vm_bms_exec:s0
-/system/bin/mm-qcamera-daemon                   u:object_r:mm-qcamerad_exec:s0
+/system/vendor/bin/mm-qcamera-daemon            u:object_r:mm-qcamerad_exec:s0
 /system/bin/qfp-daemon                          u:object_r:qfp-daemon_exec:s0
 /system/rfs.*                                   u:object_r:rfs_system_file:s0
 /system/bin/time_daemon                         u:object_r:time_daemon_exec:s0


### PR DESCRIPTION
The binary has moved to /system/vendor/bin/ too.

Signed-off-by: Julien Bolard jbolard@genymobile.com
