### PR TITLE
sepolicy: remove double rtc definition

### DIFF
--- a/common/file_contexts
+++ b/common/file_contexts
@@ -16,7 +16,6 @@
 /dev/qseecom                                    u:object_r:tee_device:s0
 /dev/seemplog                                   u:object_r:seemplog_device:s0
 /dev/radio0                                     u:object_r:fm_radio_device:s0
-/dev/rtc0                                       u:object_r:rtc_device:s0
 /dev/sensors                                    u:object_r:sensors_device:s0
 /dev/smd.*                                      u:object_r:smd_device:s0
 /dev/smem_log                                   u:object_r:smem_log_device:s0


### PR DESCRIPTION
this was moved to platform/external/sepolicy see:
https://android.googlesource.com/platform/external/sepolicy/+/android-6.0.0_r26/file_contexts#80

Signed-off-by: David Viteri davidteri91@gmail.com
