### PR TITLE
Revert Sony specific changes to sepolicy

### DIFF
--- a/common/file_contexts
+++ b/common/file_contexts
@@ -147,7 +147,7 @@
 /system/bin/test_diag                           u:object_r:diag_exec:s0
 /system/vendor/bin/thermal-engine               u:object_r:thermal-engine_exec:s0
 /system/bin/vm_bms                              u:object_r:vm_bms_exec:s0
-/system/vendor/bin/mm-qcamera-daemon            u:object_r:mm-qcamerad_exec:s0
+/system/bin/mm-qcamera-daemon                   u:object_r:mm-qcamerad_exec:s0
 /system/bin/qfp-daemon                          u:object_r:qfp-daemon_exec:s0
 /system/rfs.*                                   u:object_r:rfs_system_file:s0
 /system/bin/time_daemon                         u:object_r:time_daemon_exec:s0

--- a/common/file_contexts
+++ b/common/file_contexts
@@ -125,7 +125,7 @@
 /system/bin/diag_uart_log                       u:object_r:diag_exec:s0
 /system/bin/diag_buffering_test                 u:object_r:diag_exec:s0
 /system/bin/drmdiagapp                          u:object_r:diag_exec:s0
-/system/vendor/bin/irsc_util                    u:object_r:irsc_util_exec:s0
+/system/bin/irsc_util                           u:object_r:irsc_util_exec:s0
 /system/vendor/bin/mm-pp-daemon                 u:object_r:mm-pp-daemon_exec:s0
 /system/vendor/bin/mm-pp-dpps                   u:object_r:mm-pp-daemon_exec:s0
 /system/bin/mm-pp-daemon                        u:object_r:mm-pp-daemon_exec:s0
@@ -139,10 +139,10 @@
 /system/bin/imsqmidaemon                        u:object_r:ims_exec:s0
 /system/bin/ims_rtp_daemon                      u:object_r:ims_exec:s0
 /system/bin/imscmservice                        u:object_r:imscm_exec:s0
-/system/vendor/bin/netmgrd                      u:object_r:netmgrd_exec:s0
-/system/vendor/bin/qmuxd                        u:object_r:qmuxd_exec:s0
+/system/bin/netmgrd                             u:object_r:netmgrd_exec:s0
+/system/bin/qmuxd                               u:object_r:qmuxd_exec:s0
 /system/bin/port-bridge                         u:object_r:port-bridge_exec:s0
-/system/vendor/bin/sensors.qcom                 u:object_r:sensors_exec:s0
+/system/bin/sensors.qcom                        u:object_r:sensors_exec:s0
 /system/bin/sns.*                               u:object_r:sensors_test_exec:s0
 /system/bin/test_diag                           u:object_r:diag_exec:s0
 /system/vendor/bin/thermal-engine               u:object_r:thermal-engine_exec:s0
@@ -151,7 +151,7 @@
 /system/bin/qfp-daemon                          u:object_r:qfp-daemon_exec:s0
 /system/rfs.*                                   u:object_r:rfs_system_file:s0
 /system/bin/time_daemon                         u:object_r:time_daemon_exec:s0
-/system/vendor/bin/rmt_storage                  u:object_r:rmt_storage_exec:s0
+/system/bin/rmt_storage                         u:object_r:rmt_storage_exec:s0
 /system/bin/rfs_access                          u:object_r:rfs_access_exec:s0
 /system/bin/tftp_server                         u:object_r:rfs_access_exec:s0
 /system/bin/hvdcp                               u:object_r:hvdcp_exec:s0

--- a/common/file_contexts
+++ b/common/file_contexts
@@ -194,7 +194,7 @@
 /system/bin/dts_configurator                    u:object_r:dtsconfigurator_exec:s0
 /system/bin/dts_eagle_service                   u:object_r:dtseagleservice_exec:s0
 /system/vendor/bin/qti                          u:object_r:qti_exec:s0
-/system/vendor/bin/wcnss_service                u:object_r:wcnss_service_exec:s0
+/system/bin/wcnss_service                       u:object_r:wcnss_service_exec:s0
 /system/vendor/bin/hbtp_daemon                  u:object_r:hbtp_exec:s0
 /system/vendor/bin/touch_fusion                 u:object_r:touchfusion_exec:s0
 /system/vendor/bin/seemp_healthd                u:object_r:seemp_health_daemon_exec:s0


### PR DESCRIPTION
Sony specific changes MUST be in Sony platform sepolicy. We wish to be compatible not only with AOSP but also any other project based on AOSP. Some of those projects have their own, customized qcom/sepolicy repos and we will lose these changes on those projects.

For reference see Yukon on how we should do this: sonyxperiadev/device-sony-yukon@8266751
