### PR TITLE
common: Fix nfc denials

### DIFF
--- a/common/nfc.te
+++ b/common/nfc.te
@@ -1,3 +1,4 @@
 qmux_socket(nfc);
 allow nfc nfc_data_file:file x_file_perms;
 allow nfc self:socket create_socket_perms;
+allow nfc device:chr_file { ioctl };


### PR DESCRIPTION
<38>[   25.111303] type=1400 audit(1448642640.479:40): avc: denied { ioctl } for pid=1627 comm=4173796E635461736B202331 path="/dev/pn54x" dev="tmpfs" ino=12822 ioctlcmd=e901 scontext=u:r:nfc:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1
<38>[   25.572694] type=1400 audit(1448642862.589:39): avc: denied { ioctl } for pid=1629 comm=4173796E635461736B202331 path="/dev/pn54x" dev="tmpfs" ino=13321 ioctlcmd=e901 scontext=u:r:nfc:s0 tcontext=u:object_r:device:s0 tclass=chr_file permissive=1

Signed-off-by: Humberto Borba humberos@gmail.com
Change-Id: Ie5dcb1248257a0d23f5d68fe79d332a4b62cd9a8
